### PR TITLE
Develop_컨트롤러 연결 해제 및 게임 동기화에 관한 기능 추가 구현

### DIFF
--- a/constants/socket.js
+++ b/constants/socket.js
@@ -76,6 +76,10 @@ const SocketEvent = {
   SEND_TEST: 'sendTest',
   RECEIVE_TEST: 'receiveTest',
   RECEIVE_EXPIRE_CONTROLLER: 'receiveExpireController',
+  SEND_SYNC_GAME: 'sendSyncGame',
+  RECEIVE_SYNC_GAME: 'receiveSyncGame',
+  SEND_HOST_IS_IN_FOCUS: 'sendHostIsInFocus',
+  SEND_HOST_IS_NOT_IN_FOCUS: 'sendHostIsNotInFocus',
 };
 
 Object.freeze(SocketEvent);

--- a/constants/socket.js
+++ b/constants/socket.js
@@ -13,7 +13,6 @@ const SocketEvent = {
   LOAD_CONTROLLER_MOTION_SETTING_PAGE: 'loadControllerMotionSettingPage',
   LOAD_CONTROLLER_LEFT_SETTING_PAGE: 'loadControllerLeftSettingPage',
   LOAD_CONTROLLER_RIGHT_SETTING_PAGE: 'loadControllerRightSettingPage',
-  LOAD_CONTROLLER_FORWARD_SETTING_PAGE: 'loadControllerForwardSettingPage',
   LOAD_CONTROLLER_DEFAULT_PAGE: 'loadControllerDefaultPage',
   LOAD_CONTROLLER_SENSOR_ACTIVATE_PAGE: 'loadControllerSensorActivatePage',
   LOAD_CONTROLLER_SETTING_FINISH_PAGE: 'loadControllerSettingFinishPage',
@@ -24,7 +23,6 @@ const SocketEvent = {
   RECEIVE_MOTION_SETTING_BEGIN: 'receiveMotionSettingBegin',
   RECEIVE_LEFT_DATA: 'receiveLeftData',
   RECEIVE_RIGHT_DATA: 'receiveRightData',
-  RECEIVE_FORWARD_DATA: 'receiveForwardData',
   SEND_EXIT: 'sendExit',
   RECEIVE_EXIT: 'receiveExit',
   SWITCH_MOTION_SETTING_PAGE: 'switchMotionSettingPage',
@@ -77,6 +75,7 @@ const SocketEvent = {
   RECEIVE_STOP_DETECT_MOTION: 'receiveStopDetectMotion',
   SEND_TEST: 'sendTest',
   RECEIVE_TEST: 'receiveTest',
+  RECEIVE_EXPIRE_CONTROLLER: 'receiveExpireController',
 };
 
 Object.freeze(SocketEvent);

--- a/gameRoom/index.js
+++ b/gameRoom/index.js
@@ -60,6 +60,9 @@ const setGameRoom = (index, option, value) => {
     case 'isStarted':
       gameRoomList[index].isStarted = value;
       break;
+    case 'isHostInFocus':
+      gameRoomList[index].isHostInFocus = value;
+      break;
     default:
       break;
   }

--- a/socket/index.js
+++ b/socket/index.js
@@ -91,8 +91,14 @@ const socketModule = server => {
       socket.emit(SocketEvent.LOAD_CONTROLLER_SENSOR_ACTIVATE_PAGE);
     });
 
-    socket.on(SocketEvent.DISCONNECT_CONTROLLER, () => {
-      io.to(socket.userId).emit(SocketEvent.REMOVE_CONTROLLER);
+    socket.on(SocketEvent.DISCONNECT_CONTROLLER, data => {
+      if (data.sender === 'controller') {
+        io.to(socket.userId).emit(SocketEvent.REMOVE_CONTROLLER);
+      } else if (data.sender === 'settingPage') {
+        io.to(data.controllerId).emit(SocketEvent.RECEIVE_EXPIRE_CONTROLLER);
+        socket.emit(SocketEvent.REMOVE_CONTROLLER);
+        socket.controllerId = '';
+      }
     });
 
     socket.on(SocketEvent.CONTROLLER_COMPATIBILITY_SUCCESS, () => {

--- a/socket/index.js
+++ b/socket/index.js
@@ -418,13 +418,21 @@ const socketModule = server => {
     socket.on(SocketEvent.SEND_SYNC_GAME, data => {
       const { gameRoom } = findGameRoom(data.gameId);
 
-      if (gameRoom.isHostInFocus) {
-        if (data.isUserHost) {
-          io.to(data.gameId).emit(SocketEvent.RECEIVE_SYNC_GAME, data.gameData);
-        }
-      } else {
-        if (!data.isUserHost) {
-          io.to(data.gameId).emit(SocketEvent.RECEIVE_SYNC_GAME, data.gameData);
+      if (gameRoom) {
+        if (gameRoom.isHostInFocus) {
+          if (data.isUserHost) {
+            io.to(data.gameId).emit(
+              SocketEvent.RECEIVE_SYNC_GAME,
+              data.gameData,
+            );
+          }
+        } else {
+          if (!data.isUserHost) {
+            io.to(data.gameId).emit(
+              SocketEvent.RECEIVE_SYNC_GAME,
+              data.gameData,
+            );
+          }
         }
       }
     });

--- a/socket/index.js
+++ b/socket/index.js
@@ -414,6 +414,36 @@ const socketModule = server => {
     socket.on(SocketEvent.SEND_STOP_DETECT_MOTION, () => {
       io.to(socket.userId).emit(SocketEvent.RECEIVE_STOP_DETECT_MOTION);
     });
+
+    socket.on(SocketEvent.SEND_SYNC_GAME, data => {
+      const { gameRoom } = findGameRoom(data.gameId);
+
+      if (gameRoom.isHostInFocus) {
+        if (data.isUserHost) {
+          io.to(data.gameId).emit(SocketEvent.RECEIVE_SYNC_GAME, data.gameData);
+        }
+      } else {
+        if (!data.isUserHost) {
+          io.to(data.gameId).emit(SocketEvent.RECEIVE_SYNC_GAME, data.gameData);
+        }
+      }
+    });
+
+    socket.on(SocketEvent.SEND_HOST_IS_IN_FOCUS, gameId => {
+      const { gameRoomIndex } = findGameRoom(gameId);
+
+      if (gameRoomIndex !== -1) {
+        setGameRoom(gameRoomIndex, 'isHostInFocus', true);
+      }
+    });
+
+    socket.on(SocketEvent.SEND_HOST_IS_NOT_IN_FOCUS, gameId => {
+      const { gameRoomIndex } = findGameRoom(gameId);
+
+      if (gameRoomIndex !== -1) {
+        setGameRoom(gameRoomIndex, 'isHostInFocus', false);
+      }
+    });
   });
 };
 


### PR DESCRIPTION
# 개요
1.  입력 주체별 컨트롤러 연결 해제에 관한 소켓 로직을 추가하였음
2. 게임 동기화에 관한 소켓 로직을 추가하였음

## 상세
1. 어떤 주체가 컨트롤러 연결을 끊는지에 대한 정보가 요청으로 들어오면, 각 주체별 컨트롤러 연결 끊기 로직을 새롭게 작성하였음.
2. gameRoom에 대한 정보처리 중, 게임 호스트의 브라우저 창이 focus 되어있는지의 여부를 gameRoom 정보에 저장하는 기능이 새롭게 추가되었음. 
특정 유저가 실점을 할 때 본격적으로 동기화가 시작되는데, 스코어 및 게임을 다시 재개한다는 정보가 게임에 참여한 유저에게 전달된다.
이때 호스트의 브라우저창이 focus 되어있다면, 호스트의 정보를 토대로 동기화가 진행되며, 그렇지 않을 경우 클라이언트의 정보를 토대로 동기화가 진행되도록 소켓 로직을 구현하였다.   